### PR TITLE
Add support of custom file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Folderify inline a whole directory content in browserify results.
 I use it to inline my HTML templates folder when I browserify
  sites, but I guess it could be useful in many situations...
 
+##Custom file extensions
+
+By default, supported file extensions are:
+- `.es`
+- `.es6`
+- `.js`
+- `.jsx`
+The list is exposed as a property `validExtensions` on the folderify function and can be easily extended:
+```js
+var browserify = require('browserify');
+var folderify = require('folderify');
+folderify.validExtensions.push('.custom-js');
+
+var b = browserify('example/main.js');
+b.transform(folderify);
+```
 
 
 ## Contributing

--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -8,7 +8,6 @@ var through = require('through');
 var path = require('path');
 
 function folderify (file) {
-
   var data;
   var pending;
   var ifNames;
@@ -67,12 +66,10 @@ function folderify (file) {
       n.update('undefined');
     }
     if (isVarDecl(node)) {
-
       ifNames[node.parent.id.name] = true;
 
       unrequire(node.parent.init);
     } else if (isVarAssign(node)) {
-
       ifNames[node.parent.left.name] = true;
 
       unrequire(node.parent.right);
@@ -80,7 +77,6 @@ function folderify (file) {
   }
 
   function buildOriginalSource (folder, filter, options) {
-
     if (!filter) {
       filter = /^[^.].*$/;
     }
@@ -97,7 +93,6 @@ function folderify (file) {
   }
 
   function parse () {
-
     if (!isParsableFileName(itsFileName)) {
       finish(data);
       return;
@@ -119,17 +114,13 @@ function folderify (file) {
         var filesFilter;
 
         if (node.arguments.length > 1) {
-
           filesFilter = eval(node.arguments[1].source()); // eslint-disable-line no-eval
-
         }
 
         var options;
 
         if (node.arguments.length > 2) {
-
           options = eval('(' + node.arguments[2].source() + ')'); // eslint-disable-line no-eval
-
         }
 
         var originalSource;
@@ -160,21 +151,16 @@ function folderify (file) {
     });
 
     if (pending === 0) {
-
       finish(output);
     }
-
   }
 
   function end () {
-
     try {
       parse();
     } catch (err) {
-
       this.emit('error', err);
     }
-
   }
 
   itsDirName = path.dirname(file);
@@ -186,7 +172,6 @@ function folderify (file) {
   tr = through(write, end);
 
   return tr;
-
 }
 
 module.exports = folderify;

--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -28,14 +28,7 @@ function folderify (file) {
   }
 
   function isParsableFileName (filename) {
-    var validExtensions = [
-      '.es',
-      '.es6',
-      '.js',
-      '.jsx'
-    ];
-
-    return validExtensions.indexOf(path.extname(filename)) >= 0;
+    return folderify.validExtensions.indexOf(path.extname(filename)) >= 0;
   }
 
   function write (buf) {
@@ -173,5 +166,12 @@ function folderify (file) {
 
   return tr;
 }
+
+folderify.validExtensions = [
+  '.es',
+  '.es6',
+  '.js',
+  '.jsx'
+];
 
 module.exports = folderify;

--- a/test/fixtures/expected/include-folder-default.custom-js
+++ b/test/fixtures/expected/include-folder-default.custom-js
@@ -1,0 +1,6 @@
+var iF = undefined;
+var files = (function(){var self={},fs = require("fs");
+self["file3OtherFile"] = "this is file3OtherContent content";
+self["file1"] = "this is file1 content";
+self["file1_1"] = "this is file1_1 content";
+return self})();

--- a/test/fixtures/source/include-folder-default.custom-js
+++ b/test/fixtures/source/include-folder-default.custom-js
@@ -1,0 +1,2 @@
+var iF = require("include-folder");
+var files = iF("./test/fixtures/files");

--- a/test/folderify_test.js
+++ b/test/folderify_test.js
@@ -126,4 +126,23 @@ describe('folderify', function () {
         }));
     });
   });
+
+  describe('Custom extensions', function () {
+    it('expose validExtensions', function () {
+      expect(folderify.validExtensions).to.be.an('array');
+    });
+
+    it('can modify validExtensions for allowing custom extensions', function (done) {
+      var origin = folderify.validExtensions;
+      folderify.validExtensions = ['.custom-js'];
+      checkTransform(
+        'fixtures/source/include-folder-default.custom-js',
+        'fixtures/expected/include-folder-default.custom-js',
+        function (err) {
+          folderify.validExtensions = origin;
+          done(err);
+        }
+      );
+    });
+  });
 });

--- a/test/folderify_test.js
+++ b/test/folderify_test.js
@@ -25,7 +25,6 @@ function checkTransform (sourcefile, expectedfile, done) {
 }
 
 describe('folderify', function () {
-
   it('is defined', function () {
     expect(folderify).to.be.an('function');
   });
@@ -73,7 +72,6 @@ describe('folderify', function () {
     var expectedBundleWithJson = rf('fixtures/expected/bundle-with-json.js');
 
     it('doesn\'t require brfs', function (done) {
-
       var b = browserify(path.join(__dirname, 'fixtures/source/bundle.js'));
       b.transform(folderify);
 
@@ -87,7 +85,6 @@ describe('folderify', function () {
     });
 
     it('supports brfs running after folderify', function (done) {
-
       var b = browserify(path.join(__dirname, 'fixtures/source/bundle.js'));
       b.transform(folderify);
       b.transform('brfs');
@@ -102,7 +99,6 @@ describe('folderify', function () {
     });
 
     it('support brfs running before folderify', function (done) {
-
       var b = browserify(__dirname + '/fixtures/source/bundle.js');
       b.transform('brfs');
       b.transform(folderify);
@@ -117,7 +113,6 @@ describe('folderify', function () {
     });
 
     it('support bundles with non JavaScript files', function (done) {
-
       var b = browserify(__dirname + '/fixtures/source/bundle-with-json.js');
       b.transform('brfs');
       b.transform(folderify);
@@ -130,6 +125,5 @@ describe('folderify', function () {
           done();
         }));
     });
-
   });
 });


### PR DESCRIPTION
folderify is not usable with custom file extension, like coffee. Exposing `validExtensions` allows developpers to modify the list of allow file extensions.