### PR TITLE
Watchify support: emit file events for each file in the folder

### DIFF
--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -6,6 +6,7 @@ var includeFolder = require('include-folder');
 var falafel = require('falafel');
 var through = require('through');
 var path = require('path');
+var fs = require('fs');
 
 function folderify (file) {
   var data;
@@ -69,7 +70,7 @@ function folderify (file) {
     }
   }
 
-  function buildOriginalSource (folder, filter, options) {
+  function buildOriginalSource (folder, filter, options, stream) {
     if (!filter) {
       filter = /^[^.].*$/;
     }
@@ -78,6 +79,14 @@ function folderify (file) {
       options = {};
     }
 
+    // Emit file events for each file in this folder.
+    // Used by a file-watcher like watchify.
+    fs.readdirSync(folder)
+      .filter(filter.test.bind(filter))
+      .map(function(file) {
+        stream.emit('file', folder + file);
+      });
+
     var fnBody = includeFolder.buildSource(folder, filter, options);
 
     return '(function(){' +
@@ -85,7 +94,7 @@ function folderify (file) {
       '})()';
   }
 
-  function parse () {
+  function parse (stream) {
     if (!isParsableFileName(itsFileName)) {
       finish(data);
       return;
@@ -118,7 +127,7 @@ function folderify (file) {
 
         var originalSource;
 
-        originalSource = buildOriginalSource(folder, filesFilter, options);
+        originalSource = buildOriginalSource(folder, filesFilter, options, stream);
 
         var brfsStream = brfs(folder + 'bogus.txt');
 
@@ -150,7 +159,7 @@ function folderify (file) {
 
   function end () {
     try {
-      parse();
+      parse(this);
     } catch (err) {
       this.emit('error', err);
     }

--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -83,7 +83,7 @@ function folderify (file) {
     // Used by a file-watcher like watchify.
     fs.readdirSync(folder)
       .filter(filter.test.bind(filter))
-      .map(function(file) {
+      .map(function (file) {
         stream.emit('file', folder + file);
       });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "browserify-transform"
   ],
   "dependencies": {
-    "brfs": "^1.4.3",
+    "brfs": "~1.0.2",
     "concat-stream": "^1.5.0",
     "falafel": "^1.2.0",
     "include-folder": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "browserify-transform"
   ],
   "dependencies": {
-    "brfs": "~1.0.2",
+    "brfs": "^1.4.3",
     "concat-stream": "^1.5.0",
     "falafel": "^1.2.0",
     "include-folder": "^1.0.0",


### PR DESCRIPTION
This change adds watchify support. All files that are included via `includeFolder` are now watched by watchify.