### PR TITLE
Fix case of include-folder parser filter isIF receiving a null node.arguments.

### DIFF
--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -21,6 +21,7 @@ function folderify (file) {
 
     return c &&
       node.type === 'CallExpression' &&
+      node.arguments &&
       node.arguments.length &&
       node.arguments[0].value === 'include-folder' &&
 


### PR DESCRIPTION
Ran into this case when `folderify` ran on `bignumber.js@2.1.0`. I didn't investigate very closely, but this seems like a straightforward fix.
